### PR TITLE
Adds an image of the devtools in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An Electron-based developer tool for Lynx, providing mobile debugging features.
 
+<div align="center">
+    <img src="https://lynxjs.org/assets/doc/debugging-panel-elements.png" />
+</div>
+
 ## Project Structure
 
 ``` plantext


### PR DESCRIPTION
I found no pictures of how the devtools looks like in the repo, so I'm adding this for better representation of how it works. The image source was taken from the official website.

