### PR TITLE
Updated readme for python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ An Electron-based developer tool for Lynx, providing mobile debugging features.
 - pnpm = 7.33.6
 - Git
 - Python3
+- python-is-python3
 
 ### Node.js Version Management
 

--- a/README.md
+++ b/README.md
@@ -71,11 +71,6 @@ cd lynx-devtool
 ```bash
 pnpm install
 ```
-3. Make sure that you can run python3 as python if you are in Debian:
-
-```bash
-sudo apt install python-is-python3
-```
 
 4. Sync DevTools dependencies and build it:
 

--- a/README.md
+++ b/README.md
@@ -71,14 +71,19 @@ cd lynx-devtool
 ```bash
 pnpm install
 ```
+3. Make sure that you can run python3 as python if you are in Debian:
 
-3. Sync DevTools dependencies and build it:
+```bash
+sudo apt install python-is-python3
+```
+
+4. Sync DevTools dependencies and build it:
 
 ```bash
 pnpm run build:devtools-frontend-lynx
 ```
 
-4. Start development environment:
+5. Start development environment:
 
 ```bash
 pnpm run dev


### PR DESCRIPTION
Some distros dont have python3 path keyword set as python (like Debian for example), so they need to make sure that a package like python-is-python3 is installed to avoid errors while syncing and building.