### PR TITLE
fix: fix occasional item title errors in the Thread pane

### DIFF
--- a/packages/devtools-frontend-lynx/front_end/panels/sources/ThreadsSidebarPane.ts
+++ b/packages/devtools-frontend-lynx/front_end/panels/sources/ThreadsSidebarPane.ts
@@ -86,6 +86,7 @@ export class ThreadsSidebarPane extends UI.Widget.VBox implements
     debuggerModel.addEventListener(SDK.DebuggerModel.Events.DebuggerPaused, updatePausedState);
     debuggerModel.addEventListener(SDK.DebuggerModel.Events.DebuggerResumed, updatePausedState);
     debuggerModel.runtimeModel().addEventListener(SDK.RuntimeModel.Events.ExecutionContextChanged, updateTitle);
+    debuggerModel.runtimeModel().addEventListener(SDK.RuntimeModel.Events.ExecutionContextCreated, updateTitle);
     SDK.TargetManager.TargetManager.instance().addEventListener(
         SDK.TargetManager.Events.NameChanged, targetNameChanged);
 


### PR DESCRIPTION
add a lister for the RuntimeModel.Events.ExecutionContextCreated event to call the updateTitle function of ThreadsSidebarPane