### PR TITLE
Fnm support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@
 NODE_VERSION = 18.20.2
 PNPM_VERSION = 7.33.6
 
+NODE_VM=$(shell \
+		command -v nvm > /dev/null 2>&1 && echo ". ~/.nvm/nvm.sh && nvm" \
+		|| command -v fnm > /dev/null 2>&1 && echo "fnm" )
+
 # Targets
 .PHONY: all setup install build dev
 
@@ -12,8 +16,8 @@ all: setup build install dev
 setup:
 	@echo "Setting up Node.js and pnpm..."
 	corepack enable
-	. ~/.nvm/nvm.sh && nvm install $(NODE_VERSION)
-	. ~/.nvm/nvm.sh && nvm use $(NODE_VERSION)
+	$(NODE_VM) install $(NODE_VERSION)
+	$(NODE_VM) use $(NODE_VERSION)
 	npx pnpm@$(PNPM_VERSION) -v
 
 build:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ corepack enable
 # Install and use specified Node.js version with nvm
 nvm install 18.20.2
 nvm use 18.20.2
+# or fnm
+fnm install 18.20.2
+fnm use 18.20.2
+
+# You can run make setup to setup corepack and pick wich node version manager to use automatically
+make setup
 
 # Verify versions
 node -v  # Should display v18.20.2


### PR DESCRIPTION
Slightly modified the make script to pick between `nvm` and `fnm` (https://github.com/Schniz/fnm).
Both are popular Node.js version managers and some.

This changes should be non invasive, as the first Node version manager that's used is still `nvm`.

I also updated the README file to reflect the changes, and specified that the developer can run `make setup` to setup the Node.js environment automatically.

Changes tested on Linux

# future work
Add a check to tell the developer that either nvm or fnm MUST be present on system to proceed.