### PR TITLE
feat: optimize StopAtEntry message

### DIFF
--- a/src/renderer/containers/DevTool/DevTool.tsx
+++ b/src/renderer/containers/DevTool/DevTool.tsx
@@ -74,6 +74,8 @@ const DevTool = () => {
   const checkDevtoolSwitch = async () => {
     const devtoolSwitch = await switchUtils.getSwitchStatus('enable_devtool');
     const domTreeSwitch = await switchUtils.getSwitchStatus('enable_dom_tree');
+    switchUtils.getStopAtEntry('DEFAULT');
+    switchUtils.getStopAtEntry('MTS');
     const currentClientId = getSelectClientId();
     if ((!devtoolSwitch || !domTreeSwitch) && currentClientId === selectedDevice.clientId) {
       if (notificationId !== '') {

--- a/src/renderer/store/connection.ts
+++ b/src/renderer/store/connection.ts
@@ -24,6 +24,7 @@ import { t } from 'i18next';
 import create, { getStore } from '../utils/flooks';
 import useServer from './server';
 import useUser from './user';
+import * as switchUtils from '@/renderer/utils/switchUtils';
 
 export type ConnectionStoreType = ReturnType<typeof connectionStore>;
 
@@ -569,45 +570,61 @@ const connectionStore = (store: any) => ({
       store({ deviceInfoMap: { ...deviceInfoMap } });
     }
   },
-  async setStopAtEntry(value: boolean) {
-    const { selectedDevice } = store() as ConnectionStoreType;
+  async setStopAtEntryLegacy(value: boolean) {
+    const { selectedDevice, deviceInfoMap } = store() as ConnectionStoreType;
     const { clientId } = selectedDevice;
-    if (clientId) {
+    if (clientId === undefined) {
+      return;
+    }
+    try {
+      const deviceInfo = deviceInfoMap[clientId];
+      if (deviceInfo === undefined) {
+        return;
+      }
       await debugDriver.sendCustomMessageAsync({
         type: ECustomDataType.D2RStopAtEntry,
         params: { stop_at_entry: value },
         useParamsAsData: true,
         clientId
       });
-      const { deviceInfoMap } = store() as ConnectionStoreType;
-      const deviceInfo = deviceInfoMap[clientId];
-      if (deviceInfo) {
-        deviceInfo.stopAtEntry = value;
-        store({ deviceInfoMap: { ...deviceInfoMap } });
-      }
+      deviceInfo.stopAtEntry = value;
+      store({ deviceInfoMap: { ...deviceInfoMap } });
+    } catch (error: any) {
+      console.error(error.toString());
     }
   },
-  async setStopLepusAtEntry(value: boolean) {
-    const { selectedDevice } = store() as ConnectionStoreType;
+  setStopAtEntry(value: boolean) {
+    switchUtils.setStopAtEntry('DEFAULT', value);
+    const { setStopAtEntryLegacy } = store();
+    setStopAtEntryLegacy(value);
+  },
+  async setStopLepusAtEntryLegacy(value: boolean) {
+    const { selectedDevice, deviceInfoMap } = store() as ConnectionStoreType;
     const { clientId } = selectedDevice;
-    if (clientId) {
-      try {
-        await debugDriver.sendCustomMessageAsync({
-          type: ECustomDataType.D2RStopLepusAtEntry,
-          params: { stop_at_entry: value },
-          useParamsAsData: true,
-          clientId
-        });
-        const { deviceInfoMap } = store() as ConnectionStoreType;
-        const deviceInfo = deviceInfoMap[clientId];
-        if (deviceInfo) {
-          deviceInfo.stopLepusAtEntry = value;
-          store({ deviceInfoMap: { ...deviceInfoMap } });
-        }
-      } catch (error: any) {
-        message.error(error.toString());
-      }
+    if (clientId === undefined) {
+      return;
     }
+    try {
+      const deviceInfo = deviceInfoMap[clientId];
+      if (deviceInfo === undefined) {
+        return;
+      }
+      await debugDriver.sendCustomMessageAsync({
+        type: ECustomDataType.D2RStopLepusAtEntry,
+        params: { stop_at_entry: value },
+        useParamsAsData: true,
+        clientId
+      });
+      deviceInfo.stopLepusAtEntry = value;
+      store({ deviceInfoMap: { ...deviceInfoMap } });
+    } catch (error: any) {
+      console.error(error.toString());
+    }
+  },
+  setStopLepusAtEntry(value: boolean) {
+    switchUtils.setStopAtEntry('MTS', value);
+    const { setStopLepusAtEntryLegacy } = store();
+    setStopLepusAtEntryLegacy(value);
   },
   setMultiCardMode(value: boolean) {
     localStorage.setItem(KEY_MULTI_CARD_MODE, String(value));


### PR DESCRIPTION
1. Add messages "GetStopAtEntry" and "SetStopAtEntry" to get and set the state of the client's first-line breakpoints respectively. Use the parameter "type" to specify the breakpoints' type.
2. Send the new message "SetStopAtEntry" along with the old messages "D2RStopAtEntry" and "D2RStopLepusAtEntry" to avoid breaking changes.