### PR TITLE
fix: Enabling Electron allowRunningInsecureContent

### DIFF
--- a/src/main/mobile/MobilePage.ts
+++ b/src/main/mobile/MobilePage.ts
@@ -40,7 +40,6 @@ class MobilePage extends BasePage<BrowserWindow> {
         webviewTag: true,
         contextIsolation: false,
         nodeIntegrationInWorker: false,
-        allowRunningInsecureContent: true,
         preload: path.join(__dirname, 'preload.js'),
         partition: 'persist:ldt-mobile'
       }


### PR DESCRIPTION
https://github.com/lynx-family/lynx-devtool/blob/07b1e4c1fcfb777c6a60a91ff6b77b14ff4c8653/src/main/mobile/MobilePage.ts#L43-L43

Electron is secure by default through a policy banning the execution of content loaded over HTTP. Setting the `allowRunningInsecureContent` property of a `webPreferences` object to `true` will disable this policy. Enabling the execution of insecure content is strongly discouraged.


fix this problem, remove the `allowRunningInsecureContent: true` property from the `webPreferences` object in the `BrowserWindow` constructor. By omitting this property, Electron will default to its secure behavior, disallowing the execution of insecure content. This change should be made in the `onCreate` method of the `MobilePage` class, specifically in the object literal passed to the `BrowserWindow` constructor. No additional imports or code changes are required, as this is a simple configuration fix.

#### References
[Security, Native Capabilities, and Your Responsibility](https://electronjs.org/docs/tutorial/security#8-do-not-set-allowrunninginsecurecontent-to-true)
[CWE-494](https://cwe.mitre.org/data/definitions/494.html)