### PR TITLE
fix: enable trace feature on Windows and refine release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -126,9 +126,6 @@ jobs:
       - name: Build devtools-gn
         run: pnpm run build:devtools
 
-      - name: Sync devtools-dist
-        run: pnpm run sync:devtools-dist
-
       - name: Find Frontend Archive
         id: find_frontend
         run: |
@@ -208,12 +205,15 @@ jobs:
           name: devtools-frontend-lynx
           path: temp-frontend
 
-      - name: Extract DevTools Frontend
+      - name: Setup DevTools Frontend
         run: |
           mkdir -p packages/devtools-frontend-lynx/output
           ARCHIVE_PATH=$(find temp-frontend -name "devtool.frontend.lynx_*.tar.gz" | head -n 1)
-          tar -xzf "$ARCHIVE_PATH" -C packages/devtools-frontend-lynx/output
-          echo "DevTools Frontend extracted successfully"
+          mv "$ARCHIVE_PATH" packages/devtools-frontend-lynx/output/
+          echo "DevTools Frontend archive moved successfully"
+
+      - name: Sync DevTools Frontend
+        run: pnpm run sync:devtools-dist
 
       - name: Build lynx-trace
         run: pnpm run build:lynx-trace
@@ -323,16 +323,16 @@ jobs:
           name: devtools-frontend-lynx
           path: temp-frontend
 
-      - name: Extract DevTools Frontend
+      - name: Setup DevTools Frontend
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path "packages\devtools-frontend-lynx\output"
           $archivePath = Get-ChildItem -Path "temp-frontend" -Filter "devtool.frontend.lynx_*.tar.gz" | Select-Object -First 1 -ExpandProperty FullName
-          tar -xzf "$archivePath" -C "packages\devtools-frontend-lynx\output"
-          Write-Host "DevTools Frontend extracted successfully"
+          Move-Item -Path $archivePath -Destination "packages\devtools-frontend-lynx\output" -Force
+          Write-Host "DevTools Frontend archive moved successfully"
 
-      - name: Skip lynx-trace build on Windows
-        run: pnpm run build:lynx-trace
+      - name: Sync DevTools Frontend
+        run: pnpm run sync:devtools-dist
 
       - name: Download lynx-trace prebuilt artifact
         uses: robinraju/release-downloader@v1
@@ -347,7 +347,7 @@ jobs:
         shell: pwsh
         run: |
           Write-Host "Copying prebuilt lynx-trace artifact..." -ForegroundColor Cyan
-          $sourceFile = Get-ChildItem -Path "temp-lynx-trace" -Filter "perfetto-ui-release-*.tar.gz" | Select-Object -First 1
+          $sourceFile = Get-ChildItem -Path "temp-lynx-trace" -Filter "perfetto-ui-*.tar.gz" | Select-Object -First 1
           $destPath = "packages\lynx-devtool-cli\resources\lynx-trace.tar.gz"
           
           if ($sourceFile) {

--- a/packages/lynx-devtool-cli/src/cli/command/httpServer.ts
+++ b/packages/lynx-devtool-cli/src/cli/command/httpServer.ts
@@ -74,18 +74,7 @@ class HttpServer {
       app.use('/localResource/file', express.static(filePath));
       app.use('/localResource/devtool', express.static(devtoolPath, disableCacheConfig));
       
-      // Skip trace on Windows as it's not supported
-      if (process.platform !== 'win32') {
-        app.use('/localResource/trace', express.static(tracePath));
-      } else {
-        // Return 503 Service Unavailable for trace requests on Windows
-        app.use('/localResource/trace', (req, res) => {
-          res.status(503).json({
-            error: 'Trace feature is not available on Windows platform',
-            message: 'lynx-trace build is not supported on Windows. Please use macOS or Linux.'
-          });
-        });
-      }
+      app.use('/localResource/trace', express.static(tracePath));
 
       // apis
       app.post('/uploadFileToLocal', (req: any, res: any) => {


### PR DESCRIPTION
- Remove platform restriction in `httpServer.ts` to allow serving trace resources on Windows- Optimize `release.yaml`
  - Correct file matching patterns for trace artifact copying
  - Remove redundant `build:lynx-trace` step from build-and-upload-windows job
  - Use `sync:devtools-dist` for DevTools Frontend setup to fix white screen issue caused by incorrect manual extraction