### PR TITLE
chore: makes Reload easier to click

### DIFF
--- a/packages/devtools-frontend-lynx/front_end/panels/screencast/ScreencastView.ts
+++ b/packages/devtools-frontend-lynx/front_end/panels/screencast/ScreencastView.ts
@@ -715,9 +715,8 @@ export class ScreencastView extends UI.Widget.VBox implements SDK.OverlayModel.H
     UI.ARIAUtils.setAccessibleName(this._navigationForward, i18nString(UIStrings.forward));
     this._navigationReload = this._navigationBar.createChild('button', 'reload');
     UI.ARIAUtils.setAccessibleName(this._navigationReload, i18nString(UIStrings.reload));
-    let reloadText = this._navigationBar.createChild('span', 'title-heigh');
-    let tmp0 = document.createTextNode('Reload');
-    reloadText.appendChild(tmp0);
+    const reloadText = this._navigationReload.createChild('span', 'reload-label');
+    reloadText.appendChild(document.createTextNode('Reload'));
 
     const spanValue = this._navigationBar.createChild('span', 'title-heigh');
     spanValue.appendChild(document.createTextNode('SD'));

--- a/packages/devtools-frontend-lynx/front_end/panels/screencast/screencastView.css
+++ b/packages/devtools-frontend-lynx/front_end/panels/screencast/screencastView.css
@@ -88,7 +88,12 @@
 }
 
 .screencast-navigation button.reload {
+  display: flex;
+  align-items: center;
+  width: auto;
+  padding: 2px 8px 2px 2px;
   background-position-x: -37px;
+  cursor: pointer;
 }
 
 .screencast-navigation input {
@@ -124,6 +129,7 @@
   outline: none;
   -webkit-appearance: none;
   transition: all 0.2s ease;
+  cursor: pointer;
 }
 
 .screencast-navigation input.switch-component::after {


### PR DESCRIPTION
1. Increase the reload click area, often on the text

<img width="461" height="78" alt="image" src="https://github.com/user-attachments/assets/8a6b8ea1-90cb-455e-8de6-0738cc2534ca" />

3. Add cursor: pointer interaction