### PR TITLE
feat: enable editing @supports at-rules in the Styles pane

### DIFF
--- a/packages/devtools-frontend-lynx/front_end/core/sdk/CSSModel.ts
+++ b/packages/devtools-frontend-lynx/front_end/core/sdk/CSSModel.ts
@@ -466,6 +466,26 @@ export class CSSModel extends SDKModel {
     }
   }
 
+  async setSupportsText(styleSheetId: string, range: TextUtils.TextRange.TextRange, newSupportsText: string):
+      Promise<boolean> {
+    Host.userMetrics.actionTaken(Host.UserMetrics.Action.StyleRuleEdited);
+
+    try {
+      await this._ensureOriginalStyleSheetText(styleSheetId);
+      const {supports} = await this._agent.invoke_setSupportsText({styleSheetId, range, text: newSupportsText});
+
+      if (!supports) {
+        return false;
+      }
+      this._domModel.markUndoableState();
+      const edit = new Edit(styleSheetId, range, newSupportsText, supports);
+      this._fireStyleSheetChanged(styleSheetId, edit);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
   async addRule(styleSheetId: string, ruleText: string, ruleLocation: TextUtils.TextRange.TextRange):
       Promise<CSSStyleRule|null> {
     try {

--- a/packages/devtools-frontend-lynx/front_end/generated/InspectorBackendCommands.js
+++ b/packages/devtools-frontend-lynx/front_end/generated/InspectorBackendCommands.js
@@ -512,6 +512,13 @@ export function registerCommands(inspectorBackend) {
       ],
       ['containerQuery']);
   inspectorBackend.registerCommand(
+      'CSS.setSupportsText',
+      [
+        {'name': 'styleSheetId', 'type': 'string', 'optional': false},
+        {'name': 'range', 'type': 'object', 'optional': false}, {'name': 'text', 'type': 'string', 'optional': false}
+      ],
+      ['supports']);
+  inspectorBackend.registerCommand(
       'CSS.setRuleSelector',
       [
         {'name': 'styleSheetId', 'type': 'string', 'optional': false},

--- a/packages/devtools-frontend-lynx/front_end/generated/protocol-mapping.d.ts
+++ b/packages/devtools-frontend-lynx/front_end/generated/protocol-mapping.d.ts
@@ -1012,6 +1012,11 @@ export namespace ProtocolMapping {
       paramsType: [Protocol.CSS.SetContainerQueryTextRequest]; returnType: Protocol.CSS.SetContainerQueryTextResponse;
     };
     /**
+     * Modifies the expression of a supports at-rule.
+     */
+    'CSS.setSupportsText':
+        {paramsType: [Protocol.CSS.SetSupportsTextRequest]; returnType: Protocol.CSS.SetSupportsTextResponse;};
+    /**
      * Modifies the rule selector.
      */
     'CSS.setRuleSelector':

--- a/packages/devtools-frontend-lynx/front_end/generated/protocol-proxy-api.d.ts
+++ b/packages/devtools-frontend-lynx/front_end/generated/protocol-proxy-api.d.ts
@@ -645,6 +645,12 @@ declare namespace ProtocolProxyApi {
         Promise<Protocol.CSS.SetContainerQueryTextResponse>;
 
     /**
+     * Modifies the expression of a supports at-rule.
+     */
+    invoke_setSupportsText(params: Protocol.CSS.SetSupportsTextRequest):
+        Promise<Protocol.CSS.SetSupportsTextResponse>;
+
+    /**
      * Modifies the rule selector.
      */
     invoke_setRuleSelector(params: Protocol.CSS.SetRuleSelectorRequest): Promise<Protocol.CSS.SetRuleSelectorResponse>;

--- a/packages/devtools-frontend-lynx/front_end/generated/protocol.d.ts
+++ b/packages/devtools-frontend-lynx/front_end/generated/protocol.d.ts
@@ -2509,6 +2509,19 @@ declare namespace Protocol {
       containerQuery: CSSContainerQuery;
     }
 
+    export interface SetSupportsTextRequest {
+      styleSheetId: StyleSheetId;
+      range: SourceRange;
+      text: string;
+    }
+
+    export interface SetSupportsTextResponse extends ProtocolResponseWithError {
+      /**
+       * The resulting CSS Supports rule after modification.
+       */
+      supports: CSSSupports;
+    }
+
     export interface SetRuleSelectorRequest {
       styleSheetId: StyleSheetId;
       range: SourceRange;

--- a/packages/devtools-frontend-lynx/front_end/panels/elements/StylesSidebarPane.ts
+++ b/packages/devtools-frontend-lynx/front_end/panels/elements/StylesSidebarPane.ts
@@ -2255,9 +2255,9 @@ export class StylePropertiesSection {
     return true;
   }
 
-  _editingMediaCommitted(
+  async _editingMediaCommitted(
       query: SDK.CSSQuery.CSSQuery, element: Element, newContent: string, _oldContent: string,
-      _context: Context|undefined, _moveDirection: string): void {
+      _context: Context|undefined, _moveDirection: string): Promise<void> {
     this._parentPane.setEditingStyle(false);
     this._editingMediaFinished(element);
 
@@ -2265,23 +2265,26 @@ export class StylePropertiesSection {
       newContent = newContent.trim();
     }
 
-    function userCallback(this: StylePropertiesSection, success: boolean): void {
-      if (success) {
-        this._matchedStyles.resetActiveProperties();
-        this._parentPane._refreshUpdate(this);
-      }
-      this._parentPane.setUserOperation(false);
-      this._editingMediaTextCommittedForTest();
-    }
-
     // This gets deleted in finishOperation(), which is called both on success and failure.
     this._parentPane.setUserOperation(true);
     const cssModel = this._parentPane.cssModel();
     if (cssModel && query.styleSheetId) {
-      const setQueryText =
-          query instanceof SDK.CSSMedia.CSSMedia ? cssModel.setMediaText : cssModel.setContainerQueryText;
-      setQueryText.call(cssModel, query.styleSheetId, (query.range as TextUtils.TextRange.TextRange), newContent)
-          .then(userCallback.bind(this));
+      const range = query.range as TextUtils.TextRange.TextRange;
+      let success = false;
+      if (query instanceof SDK.CSSContainerQuery.CSSContainerQuery) {
+        success = await cssModel.setContainerQueryText(query.styleSheetId, range, newContent);
+      } else if (query instanceof SDK.CSSSupports.CSSSupports) {
+        success = await cssModel.setSupportsText(query.styleSheetId, range, newContent);
+      } else {
+        success = await cssModel.setMediaText(query.styleSheetId, range, newContent);
+      }
+
+      this._parentPane.setUserOperation(false);
+      if (success) {
+        this._matchedStyles.resetActiveProperties();
+        this._parentPane.forceUpdate();
+      }
+      this._editingMediaTextCommittedForTest();
     }
   }
 

--- a/packages/devtools-frontend-lynx/third_party/blink/public/devtools_protocol/browser_protocol.json
+++ b/packages/devtools-frontend-lynx/third_party/blink/public/devtools_protocol/browser_protocol.json
@@ -3761,6 +3761,32 @@
                     ]
                 },
                 {
+                    "name": "setSupportsText",
+                    "description": "Modifies the expression of a supports at-rule.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "styleSheetId",
+                            "$ref": "StyleSheetId"
+                        },
+                        {
+                            "name": "range",
+                            "$ref": "SourceRange"
+                        },
+                        {
+                            "name": "text",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "supports",
+                            "description": "The resulting CSS Supports rule after modification.",
+                            "$ref": "CSSSupports"
+                        }
+                    ]
+                },
+                {
                     "name": "setRuleSelector",
                     "description": "Modifies the rule selector.",
                     "parameters": [

--- a/packages/devtools-frontend-lynx/third_party/blink/public/devtools_protocol/browser_protocol.pdl
+++ b/packages/devtools-frontend-lynx/third_party/blink/public/devtools_protocol/browser_protocol.pdl
@@ -1740,6 +1740,16 @@ experimental domain CSS
       # The resulting CSS container query rule after modification.
       CSSContainerQuery containerQuery
 
+  # Modifies the expression of a supports at-rule.
+  experimental command setSupportsText
+    parameters
+      StyleSheetId styleSheetId
+      SourceRange range
+      string text
+    returns
+      # The resulting CSS Supports rule after modification.
+      CSSSupports supports
+
   # Modifies the rule selector.
   command setRuleSelector
     parameters


### PR DESCRIPTION
## Summary
- Allow double-clicking a rendered `@supports` condition in the Elements Styles sidebar to edit it, mirroring the existing `@media` and `@container` query editing flow.
- Add the `CSS.setSupportsText` CDP command across the protocol definitions and the checked-in generated files, and wire it through the SDK and the Styles panel.
- Builds on the earlier "display `@supports`" change (#131); this is the second step that makes those at-rules editable.

## Changes
- **Protocol** (`browser_protocol.pdl` / `browser_protocol.json`): add `setSupportsText` command returning `CSSSupports`.
- **Generated** (`protocol.d.ts`, `protocol-proxy-api.d.ts`, `protocol-mapping.d.ts`, `InspectorBackendCommands.js`): add the request/response types, `invoke_setSupportsText`, the command mapping, and — importantly — the runtime command registration so `invoke_setSupportsText` exists at runtime.
- **SDK** (`CSSModel.ts`): add `setSupportsText()` following `setContainerQueryText()`.
- **Panel** (`StylesSidebarPane.ts`): make `_editingMediaCommitted` async and dispatch edits by `CSSQuery` type (`CSSContainerQuery` / `CSSSupports` / `CSSMedia`).

Ported from ChromeDevTools/devtools-frontend@bec8c59.

## Test plan
- [x] Balance check: per file, `setContainerQueryText` and `setSupportsText` occurrence counts match.
- [x] `browser_protocol.json` parses as valid JSON.
- [x] `tsc` type-check passes (exit 0) for both the `sdk` and `elements` modules via their generated tsconfigs.
- [x] Runtime smoke: double-click a `@supports` condition in the Styles sidebar and confirm the edit is applied (requires a backend engine that supports `CSS.setSupportsText`).